### PR TITLE
Add missing shebang to `download_tools_somatic.sh`

### DIFF
--- a/data/download_tools_somatic.sh
+++ b/data/download_tools_somatic.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 set -e
 set -o pipefail
 set -o verbose


### PR DESCRIPTION
A missing shebang in `download_tools_somatic.sh` causes the script to fail in `sh` or other shells.