### PR TITLE
Changed back to old annotation gtf

### DIFF
--- a/src/Pipelines/analyze_rna.php
+++ b/src/Pipelines/analyze_rna.php
@@ -65,7 +65,7 @@ $target_file = $sys['target_file'];
 $genome = get_path("data_folder")."/genomes/STAR/{$build}/";
 
 //determine gtf from build
-$gtfFile = get_path("data_folder")."/dbs/Ensembl/Homo_sapiens.GRCh38.107.chr.gtf";
+$gtfFile = get_path("data_folder")."/dbs/gene_annotations/{$build}.gtf";
 
 //find FASTQ files
 $in_for = glob($folder."/*_R1_001.fastq.gz");


### PR DESCRIPTION
Hey Marc,

im Zuge der Änderungen in megSAP bzgl. der Referenzen ist für die Annotationen jetzt offensichtlich GRCh38 hardgecoded. Allerdings analysieren wir im NCCT ja auch viel Maus RNA. Ich habe erstmal wieder die ursprüngliche Zeile widerhergestellt, da ich eine dringende differential gene expression Analyse auf mit Maus DNA machen muss. Passt das so?

LG
Jan