### PR TITLE
data_setup: remove pidfile after completion

### DIFF
--- a/src/Tools/data_setup.php
+++ b/src/Tools/data_setup.php
@@ -298,4 +298,14 @@ if ($build=="GRCh38" && $check)
 	}
 }
 
+// Remove PID file if it is still ours
+$current_pidfile_pid = trim(file_get_contents($pid_file));
+if ($current_pidfile_pid==getmypid())
+{
+	unlink($pid_file);
+}
+else
+{
+	print "PID file was overwritten by another process ($current_pidfile_pid). Not removing it.\n";
+}
 ?>


### PR DESCRIPTION
We currently run the `vc` and `cn` steps in parallel. `data_setup` seems to run in the same context as the rest of the step, thus the PID is the same for the whole step. As a result, whichever step starts last will wait for the 3-hour period because it thinks that data is still being set up while the rest of the pipeline step is running. Cleaning up the pidfile after setup should handle that gracefully.