### PR TITLE
fix: remove unnecessary `apt-get update` command

### DIFF
--- a/data/tools/container_recipes/megSAP_container.def
+++ b/data/tools/container_recipes/megSAP_container.def
@@ -22,7 +22,6 @@ From: ubuntu:24.04
 		ghostscript
 		
 	# Install php
-	apt-get update
 	apt-get install -y software-properties-common
 	add-apt-repository ppa:ondrej/php
 	apt-get update


### PR DESCRIPTION
Just a minimal fix. `apt-get update` is already done previously (and only needed after adding the ppa anyway).