### PR TITLE
Pacbio integration

### DIFF
--- a/src/Common/functions.php
+++ b/src/Common/functions.php
@@ -730,7 +730,7 @@ function execApptainer($container, $command, $parameters, $in_files=[], $out_fol
 	$apptainer_args = [];
 	$apptainer_args[] = "--no-mount home,cwd";
 	$apptainer_args[] = "--cleanenv";
-	if ($container=="samtools" || $container=="methylartist") //samtools needs REF_CACHE to avoid re-initializing the reference cache inside the container every call: http://www.htslib.org/doc/samtools.html#ENVIRONMENT_VARIABLES
+	if ($container=="samtools" || $container=="methylartist" || $container=="straglrOn") //samtools needs REF_CACHE to avoid re-initializing the reference cache inside the container every call: http://www.htslib.org/doc/samtools.html#ENVIRONMENT_VARIABLES
 	{
 		$apptainer_args[] = "--env REF_CACHE=".get_path("local_data")."/samtools_ref_cache/%2s/%2s/%s";
 	}

--- a/src/Common/genomics.php
+++ b/src/Common/genomics.php
@@ -2492,4 +2492,18 @@ function compare_bam_read_count($bam_file1, $bam_file2, $threads = 4, $throw_err
 	}
 }
 
+/**
+    @brief Determines the sequencing platform type for a processing system.
+    @param string $name_short Short name of the processing system.
+    @return string 'PB', 'ONT'.
+*/
+function get_longread_sequencing_platform($name_short)
+{
+	// TODO: use better way than short name comparison
+    if (strpos($name_short, 'LR-PB-') === 0) {
+        return 'PB';
+    } else {
+        return 'ONT';
+    }
+}
 ?>

--- a/src/Common/genomics.php
+++ b/src/Common/genomics.php
@@ -2500,7 +2500,7 @@ function compare_bam_read_count($bam_file1, $bam_file2, $threads = 4, $throw_err
 function get_longread_sequencing_platform($name_short)
 {
 	// TODO: use better way than short name comparison
-    if (strpos($name_short, 'LR-PB-') === 0) {
+    if (starts_with($name_short, 'LR-PB-')) {
         return 'PB';
     } else {
         return 'ONT';

--- a/src/Pipelines/analyze_longread.php
+++ b/src/Pipelines/analyze_longread.php
@@ -41,6 +41,7 @@ $parser->logServerEnvronment();
 //determine processing system
 $sys = load_system($system, $name);
 $build = $sys['build'];
+$platform = get_longread_sequencing_platform($sys['name_short']);
 
 //check steps
 $steps = explode(",", $steps);
@@ -387,7 +388,7 @@ if(db_is_enabled("NGSD") && !$no_gender_check)
 //variant calling
 if (in_array("vc", $steps))
 {
-	if ($sys['name_short'] == "LR-PB-SPRQ")
+	if ($platform == "PB")
 	{
 		$args = [];
 		$args[] = "-model_type PACBIO";
@@ -408,7 +409,7 @@ if (in_array("vc", $steps))
 
 		$parser->execTool("Tools/vc_deepvariant.php", implode(" ", $args));
 	}
-	else 
+	else
 	{
 
 		//determine basecall model

--- a/src/Pipelines/analyze_longread.php
+++ b/src/Pipelines/analyze_longread.php
@@ -20,6 +20,7 @@ $parser->addFlag("no_sync", "Skip syncing annotation databases and genomes to th
 $parser->addFlag("no_gender_check", "Skip gender check (done between mapping and variant calling).");
 $parser->addFlag("skip_wgs_check", "Skip the similarity check with a related short-read WGS sample.");
 $parser->addFlag("bam_output", "Output file format for mapping is BAM instead of CRAM.");
+$parser->addFlag("gpu", "Use GPU supported tools where possible (currently DeepVariant in step 'vc').");
 $parser->addFloat("min_af", "Minimum VAF cutoff used for variant calling (DeepVariant 'min-alternate-fraction' parameter).", true, 0.1);
 $parser->addFloat("min_bq", "Minimum base quality used for variant calling (DeepVariant 'min-base-quality' parameter).", true, 10);
 $parser->addFloat("min_mq", "Minimum mapping quality used for variant calling (DeepVariant 'min-mapping-quality' parameter).", true, 20);
@@ -398,6 +399,11 @@ if (in_array("vc", $steps))
 		$args[] = "-min_af ".$min_af;
 		$args[] = "-min_mq ".$min_mq;
 		$args[] = "-min_bq ".$min_bq;
+
+		if ($gpu)
+		{
+			$args[] = "-gpu";
+		}
 
 		$parser->execTool("Tools/vc_deepvariant.php", implode(" ", $args));
 	}

--- a/src/Pipelines/analyze_longread.php
+++ b/src/Pipelines/analyze_longread.php
@@ -118,6 +118,8 @@ $qc_other  = $folder."/".$name."_stats_other.qcML";
 $name_sample_ps = explode("_", $name, 2);
 $sample_name = $name_sample_ps[0];
 
+if(!$sys['target_file']) trigger_error("Target region is missing in processing system config.", E_USER_NOTICE);
+
 //check if target region covers whole genome
 list($stdout, $stderr, $ec) = $parser->execApptainer("ngs-bits", "BedInfo", "-in ".realpath($sys['target_file']), [$sys['target_file']]);
 $is_wgs = false;
@@ -132,7 +134,6 @@ foreach($stdout as $line)
 	}
 }
 if(!$is_wgs) trigger_error("Target region does not cover whole genome. Cannot check for missing chromosomes in variant calls.", E_USER_NOTICE);
-
 
 //mapping
 if (in_array("ma", $steps))

--- a/src/Tools/mapping_minimap.php
+++ b/src/Tools/mapping_minimap.php
@@ -40,6 +40,7 @@ $qcml_map = $basename."_stats_map.qcML";
 //extract processing system information from DB
 $sys = load_system($system, $sample);
 $genome_fasta = genome_fasta($sys['build']);
+$platform = get_longread_sequencing_platform($sys['name_short']);
 
 //set read group information
 $group_props = [];
@@ -47,12 +48,11 @@ $group_props[] = "ID:{$sample}";
 $group_props[] = "SM:{$sample}";
 $group_props[] = "LB:{$sample}";
 $group_props[] = "DT:".date("c");
-//default PL to ONT, change to PacBio if necessary
-if ($sys['name_short'] == "LR-PB-SPRQ")
+if ($platform == "PB")
 {
 	$group_props[] = "PL:PACBIO";
 }
-else
+elseif ($platform == "ONT")
 {
 	$group_props[] = "PL:ONT";
 }
@@ -68,13 +68,17 @@ if(db_is_enabled("NGSD"))
 }
 
 //set preset, default to ONT
-if ($sys['name_short'] == "LR-PB-SPRQ")
+if ($platform == "PB")
 {
 	$preset = "map-hifi";
 }
-else
+elseif ($platform == "ONT")
 {
 	$preset = "map-ont";
+}
+else
+{
+	trigger_error("Could not determine preset as platform {$platform} is unknown", E_USER_ERROR);
 }
 
 


### PR DESCRIPTION
This PR aims to integrate support for PacBio Revio generated uBam's. Mapping and Variant Calling was tested with example Revio data provided publicly by PacBio (https://downloads.pacbcloud.com/public/revio/2024Q4/WGS/GIAB_trio/HG002_rep1/). Results look good:

- [map.qcML (as .txt to allow GitHub upload)](https://github.com/user-attachments/files/20098924/PacBioHG002_01_stats_map.qcML.txt)
- [results of `validate_happy.php` after `vc`](https://github.com/user-attachments/files/20098953/validate.txt)

All downstream processing steps should be technology agnostic.

Here is an overview of the changes I made. Looking forward to your feedback!

### Adjustments in `mapping_minimap.php`:
* Updated read group (`RG`) properties to default to ONT but switch to PacBio for specific configurations (`LR-PB-SPRQ`).
* Introduced a dynamic preset selection for minimap2 (`map-ont` for ONT and `map-hifi` for PacBio), improving compatibility with different sequencing platforms.
* Updated the description of the `mapping_minimap.php` tool to reflect broader applicability to various read types, not just nanopore reads.

### Changes to Variant Calling in `analyze_longread.php` to use already present DeepVariant support of megSAP:
* Added new command-line parameters (`gpu`, `min_af`, `min_bq`, `min_mq`) to support GPU-based tools and fine-tune variant calling thresholds.
* Implemented GPU support for DeepVariant in the variant calling step

### Improved Error Handling in `analyze_longread.php`:
* Added a check to ensure the target region file is specified in the system configuration, triggering a user notice if missing.
* Improved error messaging for incomplete genome coverage in the target region, providing better feedback during processing.